### PR TITLE
Fix toggle buttons on mobile layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -230,15 +230,17 @@ form label {
 }
 
 .toggle-button {
-  width: 110px;
+  max-width: 110px;
+  width: 70%;
   background-color: #f0f4ef;
   border: 1px solid #69788c;
   height: 34px;
   color: #344966;
-  font-size: 14px;
+  font-size: 11px;
   border-radius: 5px;
   margin: 5px;
-  transition: 0.5s;
+  transition: color 0.5s ease;
+  transition: background-color 0.5s ease;
 }
 
 .toggled {
@@ -492,6 +494,10 @@ i:hover {
 
   .modal {
     width: 50%;
+  }
+
+  .toggle-button {
+    font-size: 14px;
   }
 }
 


### PR DESCRIPTION
Changed the font size of toggle buttons in mobile view to avoid text wrapping
![Screen Shot 2021-08-04 at 5 15 43 PM](https://user-images.githubusercontent.com/82540886/128271699-17ebdf9b-1e61-4356-9352-ec16994f3827.png)
